### PR TITLE
Made tree card designs consistent with one another

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,8 +170,8 @@
         </div>
         <div class="col d-flex flex-column" style="padding-left: 50px;">
             <br><br><br><br><br>
-            <h3><b>Name :</b> Makassar Ebony Tree</h3>
-            <h4><b>Scientific Name :</b> Diospyros celibica</h4>
+            <h5><b>Name :</b> Makassar Ebony Tree</h5>
+            <h5><b>Scientific Name :</b> Diospyros celibica</h5>
             <h5><b>Description :</b> Diospyros celebica (commonly known as black ebony, or Makassar ebony) is a species of flowering tree in the family Ebenaceae that is endemic to the island of Sulawesi in Indonesia. The common name Makassar ebony is for
                 the main seaport on the island, Makassar. Makassar ebony wood is variegated, streaky brown and black, and nearly always wide-striped. It is considered a highly valuable wood for turnery, fine cabinet work, and joinery, and is much sought
                 for posts in traditional Japanese houses.
@@ -189,8 +189,8 @@
         </div>
         <div class="col d-flex flex-column" style="padding-left: 50px;">
             <br><br><br><br><br>
-            <h3><b>Name :</b> White Oak Tree</h3>
-            <h4><b>Scientific Name :</b> Quercus Alba </h4>
+            <h5><b>Name :</b> White Oak Tree</h5>
+            <h5><b>Scientific Name :</b> Quercus Alba </h5>
             <h5><b>Description :</b> Quercus Alba (commonly known as white oak tree) is one of the preeminent hardwoods of eastern and central North America. It is a long-lived oak, native to eastern and central North America and found from Minnesota, Ontario,
                 Quebec, and southern Maine south as far as northern Florida and eastern Texas. Specimens have been documented to be over 450 years old. The name comes from the colour of the finished wood. In the forest it can reach a magnificent height
                 and in the open it develops into a massive broad-topped tree with large branches striking out at wide angles.
@@ -200,43 +200,38 @@
     <hr>
 
     <div class="container justify-content-center">
-
         <div class="row">
             <img id="img" src="https://image.shutterstock.com/image-vector/illustration-tall-ashoka-tree-on-600w-226525891.jpg" height="500px" width="300px" style=" margin-left:50px ;max-height: 500px; border-radius: 30px">
         </div>
-        <div class="col d-flex flex-column" style="padding-left: 50px; margin: 0 200px 200px 200px;">
+        <div class="col d-flex flex-column" style="padding-left: 50px;margin: 0 200px 200px 200px;">
             <br><br><br><br><br>
-            <h5><u>ASHOKA VRIKSHA</u>
+            <h5><strong>Name:</strong> Ashoka Vriksha</h5>
+            <br>
+            <h5><strong>Scientific Name:</strong> Saraca Asoca</h5>
+            <br>
+            <h5><strong>Description:</strong>Ashok is one of the most legendary and sacred trees of India. The Scientific name of Sita Ashok is Saraca asoca, and it belongs to Leguminosae family. This tree is native to Indian subcontinent & it is found growing naturally
+                in the Western Ghats and the Eastern Himalayas.
                 <h5>
-                    <h5>Scientifically known as SARACA ASOCA
-                        <h5>
-                            <h5>Ashok is one of the most legendary and sacred trees of India. The Scientific name of Sita Ashok is Saraca asoca, and it belongs to Leguminosae family. This tree is native to Indian subcontinent & it is found growing naturally
-                                in the Western Ghats and the Eastern Himalayas.</h5>
-
         </div>
     </div>
     <hr>
-    <section class="elder">
-        <div class="information">
-            <h5>Name:</h5>
-            <h6>Elder tree</h6>
-            <h5>Scientific name</h5>
-            <h6><em>Sambucus nigra</em></h6>
-            <h5>Details</h5>
-            <ul>
-                <li>Mature elder trees grow to a height of around 15m and can live for 60 years.</li>
-                <li>Elder is characterised by its short trunk (bole), and grey-brown, corky, furrowed bark. It has relatively few branches.</li>
-                <li>It was thought that if you burned elder wood you would see the Devil, but if you planted elder by your house it would keep the Devil away.</li>
-            </ul>
+
+    <div class="container justify-content-center">
+        <div class="row">
+            <img id="img" src="./assets/elder.jpeg" alt="A picture of an elder tree in a field, surrounded by wildlife" style="border-radius: 30px;">
         </div>
-        <div>
-            <figure>
-                <img id="img" src="./assets/elder.jpeg" alt="A picture of an elder tree in a field, surrounded by wildlife">
-                <br>
-                <figcaption>A picture of Elder tree</figcaption>
-            </figure>
+        <div class="col d-flex flex-column" style="padding-left: 50px;">
+            <br><br><br><br><br>
+            <h5><strong>Name:</strong> Elder tree</h5>
+            <br>
+            <h5><strong>Scientific Name:</strong> Sambucus nigra</h5>
+            <br>
+            <h5><strong>Description:</strong>Mature elder trees grow to a height of around 15m and can live for 60 years.
+                Elder is characterised by its short trunk (bole), and grey-brown, corky, furrowed bark. It has relatively few branches.
+                It was thought that if you burned elder wood you would see the Devil, but if you planted elder by your house it would keep the Devil away.
+                <h5>
         </div>
-    </section>
+    </div>
     <hr>
 
     <div class="container justify-content-center">


### PR DESCRIPTION
Some tree card designs were not consistent with the design layout followed by the tree cards e.g.:

![treedesold](https://user-images.githubusercontent.com/56192025/138039300-85e64b5b-f964-4f09-8356-d32b3a9eac2b.png)

I fixed the layouts and now all the tree cards follow a similar design pattern:

![image](https://user-images.githubusercontent.com/56192025/138039402-bc72642d-c747-4715-ba41-d5aea727a107.png)
![image](https://user-images.githubusercontent.com/56192025/138039424-932a253e-e781-4cbb-a30f-2da7f32d5238.png)
